### PR TITLE
Change default tldsource to publicsuffix.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ or
 
 ## TLD List Caching Notes and Operation
 
-  The first time tldtools is loaded it will attempt to call out to `http://mxr.mozilla.org/mozilla/source/netwerk/dns/src/effective_tld_names.dat?raw=1`
+  The first time tldtools is loaded it will attempt to call out to `https://publicsuffix.org/list/public_suffix_list.dat`
 to retrieve the latest TLD list.  This file is parsed, normalised and stored in `/.tlds`.  To override this outbound call and look locally, place your
 own overriding file in `/effective_tld_names.dat`
 

--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ var 	request = require('request'),
         net = require('net');
 
 TLD_TOOLS = {
-    _tldSource: 'http://mxr.mozilla.org/mozilla/source/netwerk/dns/src/effective_tld_names.dat?raw=1',
+    _tldSource: 'https://publicsuffix.org/list/public_suffix_list.dat',
     _tldLocalSource: __dirname + '/effective_tld_names.dat',
     _tldCacheOut: __dirname + '/.tlds',
 


### PR DESCRIPTION
It looks like the public suffix file from Mozilla is not longer available. I am changing it here to the one used in tldextract: https://github.com/john-kurkowski/tldextract/blob/cf5d57e3b1c395eb4e2bc01f74242091f64e8739/tldextract/tldextract.py#L70
